### PR TITLE
Fix: Keep schema consistent when there are all-day events present

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,7 @@
  * See: https://www.gatsbyjs.com/docs/node-apis/
  */
 const {google} = require("googleapis");
+const moment = require('moment-timezone');
 
 /**
  * You can uncomment the following line to verify that
@@ -94,6 +95,28 @@ exports.sourceNodes = async ({
     const children = [];
     events.forEach(event => {
       const eventNodeId = createNodeId(`${EVENT_NODE_TYPE}-${event.id}`);
+
+      // If no events have a description, then Google does not send the field.
+			// An empty value should be provided in-case queries are referencing it.
+			if(!event.description) event.description = '';
+
+			// The date field is named `date` instead of `dateTime` for all-day events.
+			// We have to translate this into the expected schema.
+			if(event.start.date && event.start.date) {
+				event.start = {
+					dateTime: moment(event.start.date).tz(calendar.timeZone).format(),
+					timeZone: calendar.timeZone
+				};
+				event.end = {
+					dateTime: moment(event.end.date).tz(calendar.timeZone).format(),
+					timeZone: calendar.timeZone
+				};
+				event.allDay = true;
+			}
+			else {
+				event.allDay = false;
+			}
+
       createNode({
         ...event,
         id: eventNodeId,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -99,13 +99,7 @@ exports.sourceNodes = async ({
       // An empty value should be provided in-case queries are referencing it.
       if(!event.description) event.description = '';
 
-      // Some events may specify either `date` or `dateTime`.
-      // These fields must be nulled if not provided so Gatsby can
-      // determine the schema more accurately.
-      if(!event.start.date) event.start.date = null;
-      if(!event.start.dateTime) event.start.dateTime = null;
-      if(!event.end.date) event.end.date = null;
-      if(!event.end.dateTime) event.end.dateTime = null;
+      event.allDay = event.start.date && event.end.date;
 
       createNode({
         ...event,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -94,6 +94,19 @@ exports.sourceNodes = async ({
     const children = [];
     events.forEach(event => {
       const eventNodeId = createNodeId(`${EVENT_NODE_TYPE}-${event.id}`);
+
+      // If no events have a description, then Google does not send the field.
+      // An empty value should be provided in-case queries are referencing it.
+      if(!event.description) event.description = '';
+
+      // Some events may specify either `date` or `dateTime`.
+      // These fields must be nulled if not provided so Gatsby can
+      // determine the schema more accurately.
+      if(!event.start.date) event.start.date = null;
+      if(!event.start.dateTime) event.start.dateTime = null;
+      if(!event.end.date) event.end.date = null;
+      if(!event.end.dateTime) event.end.dateTime = null;
+
       createNode({
         ...event,
         id: eventNodeId,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,7 @@
  * See: https://www.gatsbyjs.com/docs/node-apis/
  */
 const {google} = require("googleapis");
+const moment = require('moment-timezone');
 
 /**
  * You can uncomment the following line to verify that
@@ -99,7 +100,23 @@ exports.sourceNodes = async ({
       // An empty value should be provided in-case queries are referencing it.
       if(!event.description) event.description = '';
 
-      event.allDay = event.start.date && event.end.date;
+      if(event.start.date && event.end.date) {
+        // event is "all-day"
+        event.start = {
+          ...event.start,
+          dateTime: moment(event.start.date).tz(calendar.timeZone).format(),
+          timeZone: calendar.timeZone
+        };
+        event.end = {
+          ...event.end,
+          dateTime: moment(event.end.date).tz(calendar.timeZone).format(),
+          timeZone: calendar.timeZone
+        };
+        event.allDay = true;
+      }
+      else {
+        event.allDay = false;
+      }
 
       createNode({
         ...event,

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,19 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^8.2.0",
-    "googleapis": "^61.0.0",
-    "moment-timezone": "^0.5.32"
+    "googleapis": "^61.0.0"
   },
   "devDependencies": {},
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^8.2.0",
-    "googleapis": "^61.0.0"
+    "googleapis": "^61.0.0",
+    "moment-timezone": "^0.5.32"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
I've fixed the issue with all-day events breaking the whole thing.

You can't just dump the raw event objects coming back from Google directly into Gatsby. The events must be checked that they have a consistent schema first. When an event is marked all-day, the `start.dateTime` field changes to `start.date`, which confuses Gatsby as to which schema to accept.

I made it so that if the start and end time contain `date` instead of `dateTime`, I treat it as an all-day event and give it a timezone based on the calendar timezone, and change `date` to `dateTime`.

I've added the `allDay` boolean field to make it clear which events are all-day.